### PR TITLE
NEW: Consistency analyzer type

### DIFF
--- a/src/Analyzers/Consistency/ConsistencyAnalyzer.php
+++ b/src/Analyzers/Consistency/ConsistencyAnalyzer.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace JumpTwentyFour\ProjectAnalyzers\Analyzers\Consistency;
+
+use Enlightn\Enlightn\Analyzers\Analyzer;
+
+abstract class ConsistencyAnalyzer extends Analyzer
+{
+    /**
+     * The category of the analyzer.
+     *
+     * @var string|null
+     */
+    public $category = 'Consistency';
+}

--- a/src/Analyzers/Consistency/InvokableControllersAnalyzer.php
+++ b/src/Analyzers/Consistency/InvokableControllersAnalyzer.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace JumpTwentyFour\ProjectAnalyzers\Analyzers\Reliability;
+namespace JumpTwentyFour\ProjectAnalyzers\Analyzers\Consistency;
 
-use Enlightn\Enlightn\Analyzers\Reliability\ReliabilityAnalyzer;
 use Illuminate\Filesystem\Filesystem;
 use JumpTwentyFour\ProjectAnalyzers\Concerns\AnalyzesFiles;
 
-class InvokableControllersAnalyzer extends ReliabilityAnalyzer
+class InvokableControllersAnalyzer extends ConsistencyAnalyzer
 {
     use AnalyzesFiles;
 


### PR DESCRIPTION
I put in a pull request to get the analyzer package to support custom categories e.g. Consistency which has now been merged https://github.com/enlightn/enlightn/pull/18. This now means we can move the invocable controller check to a more appropriate category of 'Consistency'.